### PR TITLE
Fix theme folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ add this lines
 
 ```sh
 [Theme]
-Current=simple_sddm_2
+Current=simple-sddm-2
 
 [General]
 InputMethod=qtvirtualkeyboard
@@ -60,14 +60,14 @@ InputMethod=qtvirtualkeyboard
 ### Language and time format
 - By default, it is configured with 24H format. You can change to AM/PM variant by editing the theme.conf
 ```bash
-sudo nano /usr/share/sddm/themes/simple_sddm_2/theme.conf  # use any text editor with raised privileges
+sudo nano /usr/share/sddm/themes/simple-sddm-2/theme.conf  # use any text editor with raised privileges
 ```
 - `HourFormat="hh:mm AP` . Make sure to disable the above of this part
 
 ### 🖼️ Default SDDM background
-- To change the default background, put desired image in the `/usr/share/sddm/themes/simple_sddm_2/Backgrounds/` folder and add the name of the image followed by its extension (`.jpg` or `.png`) in `theme.conf` file.
+- To change the default background, put desired image in the `/usr/share/sddm/themes/simple-sddm-2/Backgrounds/` folder and add the name of the image followed by its extension (`.jpg` or `.png`) in `theme.conf` file.
 
-- You can also customize it further if you wish in the `/usr/share/sddm/themes/simple_sddm_2/theme.conf`
+- You can also customize it further if you wish in the `/usr/share/sddm/themes/simple-sddm-2/theme.conf`
 (blur, form position, etc).
 
 


### PR DESCRIPTION
The folder name is wrong, it's using underscores instead of hyphens. Theme will not be applied due to this. 

"simple_sddm_2" => "simple-sddm-2"